### PR TITLE
Add Google Gemini API key to example.env and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Before you begin, ensure you have:
 
 - Node.js 18+ installed
 - An OpenRouter API key (get one at [OpenRouter](https://openrouter.ai))
+- A Google Gemini API key (get one at [Google AI Studio](https://aistudio.google.com/app/apikey))
 
 ## Getting Started
 
@@ -39,7 +40,15 @@ bun install
 cp example.env .env.local
 ```
 
-Then edit `.env.local` and add your OpenRouter API key.
+Then edit `.env.local` and add your API keys:
+```env
+# Get your OpenRouter API key from https://openrouter.ai/
+OPENROUTER_API_KEY=your_openrouter_api_key_here
+
+# Get your Gemini API key from https://aistudio.google.com/app/apikey
+GOOGLE_GENERATIVE_AI_API_KEY=your_gemini_api_key_here
+```
+
 
 4. Run the development server:
 

--- a/example.env
+++ b/example.env
@@ -1,2 +1,5 @@
 # Your OpenRouter API key
 OPENROUTER_API_KEY=your-api-key-here 
+
+# Your GOOGLE_GENERATIVE_AI_API_KEY
+GOOGLE_GENERATIVE_AI_API_KEY=your-api-key-here 


### PR DESCRIPTION
First, thank you for creating such an outstanding project—I’ve learned a lot from it. I noticed that the project works best when a Google configuration file (specifically, the Google Gemini API key) is provided.

In this pull request, I have updated the example.env file and the README.md to include the Google Gemini API key entry. This change should help users configure the project correctly without any confusion.

Please review the changes at your convenience, and let me know if any further modifications are needed.